### PR TITLE
Logical bug fix

### DIFF
--- a/channel.sol
+++ b/channel.sol
@@ -24,7 +24,7 @@ contract Channel {
 		signer = ecrecover(h, v, r, s);
 
 		// signature is invalid, throw
-		if (signer != channelSender && signer != channelRecipient) throw;
+		if (signer != channelSender || signer != channelRecipient) throw;
 
 		proof = sha3(this, value);
 


### PR DESCRIPTION
I think this is broken in this line. ecrecover seems to return a single address, but the test requires the address be equal to the channelSender and the channelRecipient. By adding the ```||```, Alice or Bob can post... Alice or Bob's hash values, and the other party would then need to sign the hash value to release the funds.

[I asked about this here](https://www.reddit.com/r/ethereum/comments/6jmqbo/solidity_how_does_the_ecrecover_function_work_in/), and I'd love to hear your input. I first thought maybe I didn't understand ecrecover, but in the docs, it really does only return a single address unless I'm mistaken.